### PR TITLE
Test building improvements

### DIFF
--- a/testCodes/.gitignore
+++ b/testCodes/.gitignore
@@ -1,0 +1,2 @@
+test_*
+CUDA

--- a/testCodes/Makefile
+++ b/testCodes/Makefile
@@ -28,7 +28,7 @@ all: $(OBJ) $(PROG) kernels
 
 
 kernels:
-	ln -s $(SAPPOROPATH)/CUDAKernels/ CUDA/
+	rm -f CUDA && ln -s $(SAPPOROPATH)/CUDAKernels CUDA
 
 #$(PROG): $(OBJ)
 #	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -lsapporo
@@ -63,7 +63,7 @@ test_integrator_cuda : test_integrator.o
 
 
 clean:
-	/bin/rm -rf *.o *.ptx *.a $(PROG)
+	/bin/rm -rf *.o *.ptx *.a $(PROG) CUDA
 
 
 $(OBJ): $(SAPPOROPATH)/$(SAPLIB)

--- a/testCodes/Makefile
+++ b/testCodes/Makefile
@@ -1,7 +1,4 @@
-CXX = g++
-CC  = gcc
-LD  = g++ 
-F90  = ifort
+CXX ?= g++
 
 .SUFFIXES: .o .cpp .ptx .cu
 
@@ -10,12 +7,12 @@ SAPLIB2 = sapporo
 SAPLIB = lib$(SAPLIB2).a
 
 
-CUDA_TK  = /usr/local/cuda
+CUDA_TK  ?= /usr/local/cuda
 
-OFLAGS = -g  -O3 -Wall -fopenmp -Wextra -Wstrict-aliasing=2 -fopenmp
-CXXFLAGS =  -fPIC $(OFLAGS) -I$(CUDA_TK)/include 
+OFLAGS = -g  -O3 -Wall -Wextra -Wstrict-aliasing=2 -fopenmp
+CXXFLAGS +=  -fPIC -fopenmp $(OFLAGS) -I$(CUDA_TK)/include
 
-LDFLAGS = -lcuda -fopenmp  -L$(CUDA_TK)/lib64
+LDFLAGS += -lcuda -fopenmp -L$(CUDA_TK)/lib64
 
 INCLUDEPATH = $(SAPPOROPATH)/include 
 CXXFLAGS  += -I$(INCLUDEPATH) -I./ -I $(SAPPOROPATH)
@@ -34,31 +31,31 @@ kernels:
 	ln -s $(SAPPOROPATH)/CUDAKernels/ CUDA/
 
 #$(PROG): $(OBJ)
-#	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -lsapporo
+#	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -lsapporo
 
 test_gravity_block_cuda : test_gravity_block.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_gravity_block_g5_cuda: test_gravity_block_g5.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_gravity_block_6th_cuda : test_gravity_block_6th.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)   
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)
 
 test_performance_rangeN_cuda : test_performance_rangeN.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)  
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_performance_blockStep_cuda : test_performance_blockStep.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_performance_rangeN_6th_cuda : test_performance_rangeN_6th.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_performance_rangeN_g5_cuda : test_performance_rangeN_g5.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_integrator_cuda : test_integrator.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIBG6) $(LDFLAGS)
 
 
 %.o: $(SRCPATH)/%.cpp

--- a/testCodes/Makefile_ocl
+++ b/testCodes/Makefile_ocl
@@ -1,7 +1,4 @@
-CXX = g++
-CC  = gcc
-LD  = g++ 
-F90  = ifort
+CXX ?= g++
 
 .SUFFIXES: .o .cpp .ptx .cu
 
@@ -9,13 +6,13 @@ SAPPOROPATH=../lib/
 SAPLIB2 = sapporo_ocl
 SAPLIB = lib$(SAPLIB2).a
 
-CUDA_TK  = /usr/local/cuda
+CUDA_TK  ?= /usr/local/cuda
 #CUDA_TK  = /opt/AMDAPP/
 
-OFLAGS = -g -O3 -Wall -Wextra -Wstrict-aliasing=2 -fopenmp 
-CXXFLAGS =  -fPIC $(OFLAGS) -D_OCL_
+OFLAGS = -g -O3 -Wall -Wextra -Wstrict-aliasing=2 -fopenmp
+CXXFLAGS +=  -fPIC -fopenmp $(OFLAGS) -D_OCL_
 
-LDFLAGS = -lOpenCL -fopenmp  
+LDFLAGS += -lOpenCL -fopenmp  
 
 INCLUDEPATH = $(SAPPOROPATH)/include 
 CXXFLAGS  += -I$(INCLUDEPATH) -I./ -I $(SAPPOROPATH) -I$(CUDA_TK)/include 
@@ -33,28 +30,28 @@ kernels:
 	ln -s $(SAPPOROPATH)/OpenCLKernels OpenCL
 
 test_gravity_block_ocl : test_gravity_block_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_gravity_block_g5_ocl: test_gravity_block_g5_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)
 
 test_gravity_block_6th_ocl : test_gravity_block_6th_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)   
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)   
 
 test_performance_rangeN_ocl : test_performance_rangeN_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS) 
 
 test_performance_blockStep_ocl : test_performance_blockStep_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2)  $(LDFLAGS)
 
 test_performance_rangeN_6th_ocl : test_performance_rangeN_6th_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
 
 test_performance_rangeN_g5_ocl : test_performance_rangeN_g5_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
 
 test_integrator_ocl : test_integrator_ocl.o
-	$(LD) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
+	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS) 
 
 %_ocl.o: $(SRCPATH)/%.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@


### PR DESCRIPTION
Here are some improvements for the build system of the tests:

- by adding to variables like CXXFLAGS instead of overwriting them, the user (or conda, or lmod) can set things like additional include and link directories, increasing the chances that we'll find the dependencies right away,
- calling the linker directly is not recommended these days, the compiler is much better at doing it for us than we can do it ourselves,
- make kept trying to recreate that CUDA symlink, which gave an error.

The whole symlink thing is awkward anyway, and having the kernels in separate files is a bit tricky to manage if sapporo2 is packaged separately. It seems that for OpenCL, the kernels are converted to headers and included. The conversion is also done for CUDA, but the `.ptxh` file is currently unused. I'm going to try to make that work again, it's much easier than putting separate files into `${PREFIX}/share/sapporo2/CUDA` and then trying to figure out where that is at runtime.

Actually, I think it would be better if the user just specified which kind of integrator they wanted, rather than a path to a kernel file. Then the whole OpenCL-or-CUDA thing can be abstracted away, and the user just says "give me a 6th order integrator" with sapporo2 doing the rest. But I'm trying to do the minimum to get this packaged first, improvements and optimisations can come later if they seem urgent.