### PR TITLE
Add uninstall target to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,10 @@ $(PREFIX)/lib/%: % $(PREFIX)/lib
 .PHONY: install
 install: $(INSTALLED_LIBS) $(INSTALLED_HEADERS)
 
+.PHONY: uninstall
+uninstall:
+	rm -rf $(INSTALLED_LIBS) $(INSTALLED_HEADERS)
+
 
 # Clean-up
 .PHONY: clean


### PR DESCRIPTION
This adds an uninstall target to the build system, which is nice because the AMUSE installer expects to have one available. Part of the AMUSE build system integration work for https://github.com/amusecode/amuse/issues/1209