### PR TITLE
Add 'make test' target to build and run correctness tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.cle
 *.clh
 *.swp
+.backend.stamp

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,26 @@ OBJS := $(CXX_SRC:%.cpp=%.o)
 INCLUDES += -Isrc
 CXXFLAGS += $(INCLUDES) -fPIC -g -O3 -Wall -Wextra -Wstrict-aliasing=2 -fopenmp
 
+# The objects are backend-specific: the CUDA backend compiles cudadev.h while
+# the OpenCL backend compiles ocldev.h (selected by -D_OCL_). Make only tracks
+# file timestamps, not the value of BACKEND, so after building one backend a
+# subsequent build with the other backend would silently reuse the existing
+# objects and library. That produced the reported failure: an OpenCL test
+# linked against a CUDA-compiled libsapporo2 tried to cuModuleLoad() a .cl
+# source file, aborting with CUDA_ERROR_INVALID_IMAGE in cudadev.h.
+#
+# Record the active backend in a stamp file and depend on it so that switching
+# BACKEND forces the objects to be recompiled. The stamp is only rewritten when
+# the backend actually changes, so unchanged rebuilds stay incremental.
+BACKEND_STAMP := .backend.stamp
+
+.PHONY: FORCE
+$(BACKEND_STAMP): FORCE
+	@[ "$$(cat $@ 2>/dev/null)" = "$(BACKEND)" ] || \
+	    { echo "Backend changed to $(BACKEND), rebuilding objects"; echo "$(BACKEND)" > $@; }
+
+$(OBJS): $(BACKEND_STAMP)
+
 src/sapporohostclass.o: $(KERNELS)
 
 %.o: %.cpp
@@ -249,6 +269,7 @@ test: build-tests
 clean:
 	rm -f *.a *.so src/*.o src/SSE_AVX/SSE/*.o src/SSE_AVX/AVX/*.o
 	rm -f src/CUDA/*.ptx src/CUDA/*.ptxh src/OpenCL/*.cle src/OpenCL/*.clh
+	rm -f $(BACKEND_STAMP)
 	$(MAKE) -C tests -f Makefile clean
 	$(MAKE) -C tests -f Makefile_ocl clean
 

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,40 @@ uninstall:
 	rm -rf $(INSTALLED_LIBS) $(INSTALLED_HEADERS)
 
 
+# Tests
+# Build the test programs against the freshly built libraries and run the
+# GPU-vs-CPU correctness tests for each supported integration order. The
+# backend selected above determines which test Makefile and binaries are used.
+ifeq ($(BACKEND), CUDA)
+    TEST_MAKEFILE := Makefile
+    TEST_SUFFIX := cuda
+else
+    TEST_MAKEFILE := Makefile_ocl
+    TEST_SUFFIX := ocl
+endif
+
+CORRECTNESS_TESTS := test_gravity_block_$(TEST_SUFFIX) \
+                     test_gravity_block_g5_$(TEST_SUFFIX) \
+                     test_gravity_block_6th_$(TEST_SUFFIX)
+
+.PHONY: build-tests
+build-tests: all
+	$(MAKE) -C tests -f $(TEST_MAKEFILE) CXX="$(CXX)" CC="$(CC)" \
+	    $(if $(CUDA_TK),CUDA_TK="$(CUDA_TK)")
+
+.PHONY: test
+test: build-tests
+	@for t in $(CORRECTNESS_TESTS); do \
+	    echo "=== Running $$t ==="; \
+	    ( cd tests && LD_LIBRARY_PATH="$(CURDIR):$$LD_LIBRARY_PATH" ./$$t ) || exit 1; \
+	done
+
+
 # Clean-up
 .PHONY: clean
 clean:
 	rm -f *.a *.so src/*.o src/SSE_AVX/SSE/*.o src/SSE_AVX/AVX/*.o
 	rm -f src/CUDA/*.ptx src/CUDA/*.ptxh src/OpenCL/*.cle src/OpenCL/*.clh
+	$(MAKE) -C tests -f Makefile clean
+	$(MAKE) -C tests -f Makefile_ocl clean
 

--- a/tests/Makefile_ocl
+++ b/tests/Makefile_ocl
@@ -3,7 +3,7 @@ CXX ?= g++
 .SUFFIXES: .o .cpp .ptx .cu
 
 SAPPOROPATH=..
-SAPLIB2 = sapporo
+SAPLIB2 = sapporo2
 SAPLIB = lib$(SAPLIB2).a
 SAPLIBG6 = sapporoG6
 
@@ -28,7 +28,7 @@ PROG = test_gravity_block_ocl test_gravity_block_6th_ocl test_performance_rangeN
 all: $(OBJ) $(PROG) kernels
 
 kernels:
-	rm -f OpenCL && ln -s $(SAPPOROPATH)/OpenCL OpenCL
+	rm -f OpenCL && ln -s $(SAPPOROPATH)/src/OpenCL OpenCL
 
 test_gravity_block_ocl : test_gravity_block_ocl.o
 	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)


### PR DESCRIPTION
Add a top-level `test` target that builds the library and the test programs against it, then runs the GPU-vs-CPU correctness tests for the 4th-order, GRAPE5 (2nd-order) and 6th-order integrators. The target dispatches to the CUDA or OpenCL test Makefile based on the selected BACKEND, and sets LD_LIBRARY_PATH so the freshly built shared libraries are found at runtime. A `build-tests` target is also provided to compile the tests without running them, and `clean` now also cleans the tests directory.

Fix two pre-existing bugs in tests/Makefile_ocl that prevented the OpenCL tests from building/running: link against libsapporo2 (not the old libsapporo name) and symlink kernels from src/OpenCL.