### PR TITLE
Enable make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ uninstall:
 
 # Tests
 # Build the test programs against the freshly built libraries and run the
-# GPU-vs-CPU correctness tests for each supported integration order. The
+# GPU-vs-CPU performance tests for each supported integration order. The
 # backend selected above determines which test Makefile and binaries are used.
 ifeq ($(BACKEND), CUDA)
     TEST_MAKEFILE := Makefile

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,40 @@ uninstall:
 	rm -rf $(INSTALLED_LIBS) $(INSTALLED_HEADERS)
 
 
+# Tests
+# Build the test programs against the freshly built libraries and run the
+# GPU-vs-CPU correctness tests for each supported integration order. The
+# backend selected above determines which test Makefile and binaries are used.
+ifeq ($(BACKEND), CUDA)
+    TEST_MAKEFILE := Makefile
+    TEST_SUFFIX := cuda
+else
+    TEST_MAKEFILE := Makefile_ocl
+    TEST_SUFFIX := ocl
+endif
+
+CORRECTNESS_TESTS := test_gravity_block_$(TEST_SUFFIX) \
+                     test_gravity_block_g5_$(TEST_SUFFIX) \
+                     test_gravity_block_6th_$(TEST_SUFFIX)
+
+.PHONY: build-tests
+build-tests: all
+	$(MAKE) -C tests -f $(TEST_MAKEFILE) CXX="$(CXX)" CC="$(CC)" \
+	    $(if $(CUDA_TK),CUDA_TK="$(CUDA_TK)")
+
+.PHONY: test
+test: build-tests
+	@for t in $(CORRECTNESS_TESTS); do \
+	    echo "=== Running $$t ==="; \
+	    ( cd tests && LD_LIBRARY_PATH="$(CURDIR):$$LD_LIBRARY_PATH" ./$$t ) || exit 1; \
+	done
+
+
 # Clean-up
 .PHONY: clean
 clean:
 	rm -f *.a *.so src/*.o src/SSE_AVX/SSE/*.o src/SSE_AVX/AVX/*.o
 	rm -f src/CUDA/*.ptx src/CUDA/*.ptxh src/OpenCL/*.cle src/OpenCL/*.clh
+	$(MAKE) -C tests -f Makefile clean
+	$(MAKE) -C tests -f Makefile_ocl clean
 

--- a/src/ocldev.h
+++ b/src/ocldev.h
@@ -275,7 +275,15 @@ namespace dev {
       fprintf(stderr, "Using platform %d \n", selected_platform);
       PlatformID = PlatformIDs[selected_platform];
 
-      oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount));
+      // Try to get devices of the requested type. If none are found for GPU,
+      // fall back to CPU devices (useful when using pocl or CPU-only runtimes).
+      cl_int ciErrNum = clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount);
+      if (ciErrNum == CL_DEVICE_NOT_FOUND && DeviceType == CL_DEVICE_TYPE_GPU) {
+        std::cerr << "No GPU devices found on platform, trying CPU devices...\n";
+        DeviceType = CL_DEVICE_TYPE_CPU;
+        ciErrNum = clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount);
+      }
+      oclSafeCall(ciErrNum);
 
       Devices.resize(DeviceCount);
       oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, DeviceCount, &Devices[0], &DeviceCount));

--- a/src/ocldev.h
+++ b/src/ocldev.h
@@ -257,14 +257,29 @@ namespace dev {
         oclSafeCall(clGetPlatformInfo(PlatformIDs[dev], CL_PLATFORM_NAME, sizeof(platform_string), &platform_string, NULL));
 	std::cerr << " " << dev << ": " << platform_string << "\n";
       }
-      fprintf(stderr, "Using platform %d \n", platform_id);
-      PlatformID = PlatformIDs[platform_id];
+      
+      // Prefer NVIDIA platform if available.
+      int selected_platform = platform_id;
+      if (platform_id == 0 && numPlatforms > 1) {
+        for (cl_uint p = 0; p < numPlatforms; p++) {
+          char platform_string[1024];
+          oclSafeCall(clGetPlatformInfo(PlatformIDs[p], CL_PLATFORM_NAME, sizeof(platform_string), &platform_string, NULL));
+          if (strstr(platform_string, "NVIDIA") != NULL) {
+            std::cerr << "Found NVIDIA platform at index " << p << ", preferring it over others.\n";
+            selected_platform = p;
+            break;
+          }
+        }
+      }
+      
+      fprintf(stderr, "Using platform %d \n", selected_platform);
+      PlatformID = PlatformIDs[selected_platform];
 
       oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount));
 
       Devices.resize(DeviceCount);
       oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, DeviceCount, &Devices[0], &DeviceCount));
-
+    
       std::cerr << "Found " << DeviceCount << " suitable devices: \n";
       for (cl_uint dev = 0; dev < DeviceCount; dev++) {
 	char device_string[1024];

--- a/src/ocldev.h
+++ b/src/ocldev.h
@@ -275,15 +275,7 @@ namespace dev {
       fprintf(stderr, "Using platform %d \n", selected_platform);
       PlatformID = PlatformIDs[selected_platform];
 
-      // Try to get devices of the requested type. If none are found for GPU,
-      // fall back to CPU devices (useful when using pocl or CPU-only runtimes).
-      cl_int ciErrNum = clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount);
-      if (ciErrNum == CL_DEVICE_NOT_FOUND && DeviceType == CL_DEVICE_TYPE_GPU) {
-        std::cerr << "No GPU devices found on platform, trying CPU devices...\n";
-        DeviceType = CL_DEVICE_TYPE_CPU;
-        ciErrNum = clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount);
-      }
-      oclSafeCall(ciErrNum);
+      oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, 0, NULL, &DeviceCount));
 
       Devices.resize(DeviceCount);
       oclSafeCall(clGetDeviceIDs(PlatformID, DeviceType, DeviceCount, &Devices[0], &DeviceCount));

--- a/tests/Makefile_ocl
+++ b/tests/Makefile_ocl
@@ -3,7 +3,7 @@ CXX ?= g++
 .SUFFIXES: .o .cpp .ptx .cu
 
 SAPPOROPATH=..
-SAPLIB2 = sapporo
+SAPLIB2 = sapporo2
 SAPLIB = lib$(SAPLIB2).a
 SAPLIBG6 = sapporoG6
 
@@ -28,7 +28,7 @@ PROG = test_gravity_block_ocl test_gravity_block_6th_ocl test_performance_rangeN
 all: $(OBJ) $(PROG) kernels
 
 kernels:
-	rm -f OpenCL && ln -s $(SAPPOROPATH)/OpenCL OpenCL
+	rm -f OpenCL && ln -s $(SAPPOROPATH)/src/OpenCL OpenCL
 
 test_gravity_block_ocl : test_gravity_block_ocl.o
 	$(CXX) $(LDFLAGS) $^ -o $@ -L $(SAPPOROPATH) -l$(SAPLIB2) $(LDFLAGS)


### PR DESCRIPTION
This is cherry-picked [commit c1292cb](https://github.com/v1kko/sapporo2/commit/c1292cb7924b3284a3e771a85465e4e7ff75567d) (now [commit 17fb33e](https://github.com/treecode/sapporo2/commit/17fb33eddd613c0e14b061a5195e2ea6c90ee9d4)) - `Add 'make test' target to build and run correctness tests` - 
plus commit [c1adf9d](https://github.com/treecode/sapporo2/commit/c1adf9dc0cc418062f5a4f0c81297abf2574de61) - `Try to get an NVIDIA GPU if available`.

`make clean; make all; clear; make test` works,
i.e.
`make clean; make all BACKEND=CUDA; make test BACKEND=CUDA` completes without error.

However, `make clean; make all BACKEND=OpenCL; make test BACKEND=OpenCL` yields

> === Running test_gravity_block_ocl ===
 n = 1024
./test_gravity_block_ocl is using: n: 1024	Devices: 0	IntegrationOrder: 1	IntegrationPrecision: 1	File: OpenCL/kernels4th.cl
Integration order used: 1 (0=GRAPE5, 1=4th, 2=6th, 3=8th)
Integration precision used: 1 (0=FLOAT, 1 = DOUBLESINGLE, 2=DOUBLE)
Getting list of OpenCL devices ...
 0: NVIDIA CUDA
Using platform 0 
Found 1 suitable devices: 
 0: NVIDIA RTX A5000	Vendor: NVIDIA Corporation
Number of cpus available: 48
Number of gpus available: 1
integrationOrder : 1
Getting list of OpenCL devices ...
 0: NVIDIA CUDA
Using platform 0 
Found 1 suitable devices: 
 0: NVIDIA RTX A5000	Vendor: NVIDIA Corporation
Using device: 0
Device has: 64 	 multiprocessors 
Using  16 blocks per multi-processor for a total of : 1024
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
1 warning generated.
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
1 warning generated.
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
1 warning generated.
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
1 warning generated.
Kernel files found .. building compute kernels! 
Creating kernel dev_copy_particles 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_predictor 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_evaluate_gravity_fourth_DS 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_reset_buffers 
Maximum work group size: 256 Optimal work group multiple: 32
oclSafeCall() Runtime API error in file <src/ocldev.h>, line 546 : Out of resources
.
test_gravity_block_ocl: src/ocldev.h:179: void dev::__oclsafeCall(cl_int, const char*, int): Assertion `false' failed.
/bin/sh: line 1: 1892320 Aborted                 (core dumped)

when run on a cluster node with a NVIDIA RTX A5000 GPU after `module load opencl-nvidia/12.3` on a cluster node when it gets to running `test_gravity_block_ocl`.

That same command will result in  `test_gravity_block_ocl` running "forever" - i.e. until it is killed - at 100% utilisation on a machine with CUDA 13.2 - more specifically , `nvcc --version` gives `cuda_13.2.r13.2/compiler.37668154_0` - and a NVIDIA RTX 4090 GPU:

> === Running test_gravity_block_ocl ===
 n = 1024
./test_gravity_block_ocl is using: n: 1024	Devices: 0	IntegrationOrder: 1	IntegrationPrecision: 1	File: OpenCL/kernels4th.cl
Integration order used: 1 (0=GRAPE5, 1=4th, 2=6th, 3=8th)
Integration precision used: 1 (0=FLOAT, 1 = DOUBLESINGLE, 2=DOUBLE)
Getting list of OpenCL devices ...
 0: AMD Accelerated Parallel Processing
 1: NVIDIA CUDA
Found NVIDIA platform at index 1, preferring it over others.
Using platform 1 
Found 1 suitable devices: 
 0: NVIDIA GeForce RTX 4090	Vendor: NVIDIA Corporation
Number of cpus available: 24
Number of gpus available: 1
integrationOrder : 1
Getting list of OpenCL devices ...
 0: AMD Accelerated Parallel Processing
 1: NVIDIA CUDA
Found NVIDIA platform at index 1, preferring it over others.
Using platform 1 
Found 1 suitable devices: 
 0: NVIDIA GeForce RTX 4090	Vendor: NVIDIA Corporation
Using device: 0
Device has: 128 	 multiprocessors 
Using  16 blocks per multi-processor for a total of : 2048
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
Loading file:  OpenCL/kernels4th.cl 
Opening kernel file: OpenCL/kernels4th.cl
Kernel files found .. building compute kernels! 
Creating kernel dev_copy_particles 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_predictor 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_evaluate_gravity_fourth_DS 
Maximum work group size: 256 Optimal work group multiple: 32 
Creating kernel dev_reset_buffers 
Maximum work group size: 256 Optimal work group multiple: 32 
calchalf2: 0	0.057310	0.063280	0.044715	-0.078169	-0.166680	-0.461248	-0.214907	513	0.075619
calchalf2: 1	0.076777	0.051825	0.003352	-0.163508	1.554290	0.281493	-0.334387	802	0.041755
...
...
Computing forces on GPU
cycle= 0 dn= 607 .... 

I have spent some time trying to fix this, but I did not succeed. Since OpenCL is not used often in AMUSE, I propose to merge.
